### PR TITLE
Add deprecation notice & link to React

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[**Deprecated** - You're probably looking for the package of the same name in the React repo!](https://github.com/facebook/react/tree/master/packages/react-test-renderer)
+
+---
+
 # react-test-renderer
 
 > A lightweight solution to testing fully-rendered React Components


### PR DESCRIPTION
This repo still ranks 2nd on Google and this isn't the first time I clicked on it looking for `react-test-renderer` docs/code :)

![image](https://cloud.githubusercontent.com/assets/510740/22297354/e6254a9c-e314-11e6-8da3-0600627726ec.png)
